### PR TITLE
Fix to add trailing slash to feed to prevent issue when

### DIFF
--- a/src/app/shared/services/articles.service.ts
+++ b/src/app/shared/services/articles.service.ts
@@ -23,7 +23,7 @@ export class ArticlesService {
 
     return this.apiService
     .get(
-      '/articles' + ((config.type === 'feed') ? '/feed' : ''),
+      '/articles' + ((config.type === 'feed') ? '/feed/' : ''),
       new HttpParams(params)
     );
   }


### PR DESCRIPTION
When you are using the [Django version of realworld example backend](https://github.com/gothinkster/django-realworld-example-app) app without the trailing slash, you get the error `TypeError: error.json is not a function` . This occurs because the API is returning:
```
{
    "errors": {
        "article": "An article with this slug does not exist."
    }
}
```
The value returned suggests that without the trailing slash, the URL gets trapped by [the broader article regex in urls.py](https://github.com/gothinkster/django-realworld-example-app/blob/master/conduit/apps/articles/urls.py) even though it already contains `DefaultRouter(trailing_slash=False)`.

After adding the trailing slash I get the expected result, which is in line with what I encounter when using the public API.